### PR TITLE
Fix different OG Image Url on CSR and SSR

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,8 +1,14 @@
 <script setup>
-import ogImage from '~/assets/images/og.png';
+import ogImagePath from '~/assets/images/og.png';
 
 const appConfig = useAppConfig();
 const runtimeConfig = useRuntimeConfig();
+
+// The result of imported `ogImage` in server-side is a relative path,
+// but in client-side is an absolute path based on the browser.
+const ogImageUrl = import.meta.server
+  ? `${ runtimeConfig.public.APP_URL }${ ogImagePath }`
+  : ogImagePath;
 
 useSeoMeta({
   title: appConfig.seo.title,
@@ -13,7 +19,7 @@ useSeoMeta({
   ogType: 'website',
   ogDescription: appConfig.seo.description,
   ogImage: {
-    url: `${ runtimeConfig.public.APP_URL }${ ogImage }`,
+    url: ogImageUrl,
     width: 1200,
     height: 630
   },


### PR DESCRIPTION
In previous deployment, I noticed that
  
```js
# ./app.vue
import ogImage from '~/assets/images/og.png';
```
  
On the server-side, the `ogImage` resolves to `/_nuxt/og.DPz_5dqI.png`. However, on the client-side, it resolves to `http://localhost:3000/_nuxt/og.DPz_5dqI.png`, where `http://localhost:3000` is the current URL in the browser.
  
I guess it may be caused by the use of `import.meta.url` in Vite, which return different value in server-side and client-side.
  
To fix it simply, I used `import.meta.server` to detect whether the code is running on the server or the client. Make sure final URLs are the same on both sides.